### PR TITLE
Change path for misc partition to pad partition

### DIFF
--- a/root/fstab.qcom
+++ b/root/fstab.qcom
@@ -12,7 +12,7 @@
 /dev/block/platform/msm_sdcc.1/by-name/persist        /persist           ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,nomblk_io_submit,errors=panic  wait,check
 /dev/block/platform/msm_sdcc.1/by-name/boot           /boot              emmc    defaults                                                                      defaults
 /dev/block/platform/msm_sdcc.1/by-name/recovery       /recovery          emmc    defaults                                                                      defaults
-/dev/block/platform/msm_sdcc.1/by-name/misc           /misc              emmc    defaults                                                                      defaults
+/dev/block/platform/msm_sdcc.1/by-name/pad            /misc              emmc    defaults                                                                      defaults
 #/dev/block/platform/msm_sdcc.1/by-name/modem          /firmware          vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0        wait
 /dev/block/platform/msm_sdcc.1/by-name/modem          /firmware          vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337                      wait
 


### PR DESCRIPTION
The misc one doesn't exist on the Fairphone 2.
Change for TWRP is already submitted and confirmed working: https://gerrit.twrp.me/#/c/2508/